### PR TITLE
add python base coverage report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,7 @@ catkin_package(CFG_EXTRAS code_coverage-extras.cmake)
 ## Install all cmake files
 install(DIRECTORY cmake/Modules
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/cmake)
+
+install(DIRECTORY scripts
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS)

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -192,6 +192,10 @@ function(ADD_CODE_COVERAGE)
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"
         DEPENDS create_python_base_coverage_dir
                 ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py
+                ${PROJECT_SOURCE_DIR}/bin
+                ${PROJECT_SOURCE_DIR}/node_scripts
+                ${PROJECT_SOURCE_DIR}/scripts
+                ${PROJECT_SOURCE_DIR}/src
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python_base_coverage
       )
       # hidden test target which depends on building all tests and cleaning test results
@@ -203,6 +207,10 @@ function(ADD_CODE_COVERAGE)
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"
         DEPENDS create_python_base_coverage_dir
                 ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py
+                ${PROJECT_SOURCE_DIR}/bin
+                ${PROJECT_SOURCE_DIR}/node_scripts
+                ${PROJECT_SOURCE_DIR}/scripts
+                ${PROJECT_SOURCE_DIR}/src
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python_base_coverage
       )
     else()

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -167,6 +167,8 @@ function(ADD_CODE_COVERAGE)
       )
 
       # create python base coverage report
+      # generate_base_coverage.py list up python files in the repo and generate base coverage report
+      # base coverage report is needed to cover all python files, including non-tested files.
       add_custom_target(run_tests_${PROJECT_NAME}_python_base_coverage_report
         COMMAND rosrun code_coverage generate_base_coverage.py ${PROJECT_SOURCE_DIR} --output ${PROJECT_BINARY_DIR}/python_base_coverage
         COMMAND ${PYTHON_COVERAGE_PATH} report ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No python base report to output"

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -149,6 +149,12 @@ function(ADD_CODE_COVERAGE)
     set(INCLUDE_FLAGS "--include=\"${REAL_SOURCE_DIR}/*\"")
 
     # add target for non-test repo
+    # we need to set run_tests_${PROJECT_NAME} and _run_tests_${PROJECT_NAME} for repo with no-test
+    # otherwise test fails.
+    # catkin tools executed either runrun_tests_${PROJECT_NAME} or _run_tests_${PROJECT_NAME}.
+    # run_tests_${PROJECT_NAME} and _run_tests_${PROJECT_NAME} does not run simaltaneously. 
+    # _run_tests_${PROJECT_NAME} is for cleaning test result and run tests.
+    # https://github.com/ros/catkin/commit/f931db5c8c14475a9d74ffc65b9dbbe45c98d11d
     if(NOT TARGET run_tests_${PROJECT_NAME})
       add_custom_target(run_tests_${PROJECT_NAME})
     endif()

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -152,7 +152,7 @@ function(ADD_CODE_COVERAGE)
     # we need to set run_tests_${PROJECT_NAME} and _run_tests_${PROJECT_NAME} for repo with no-test
     # otherwise test fails.
     # catkin tools executed either runrun_tests_${PROJECT_NAME} or _run_tests_${PROJECT_NAME}.
-    # run_tests_${PROJECT_NAME} and _run_tests_${PROJECT_NAME} does not run simaltaneously. 
+    # run_tests_${PROJECT_NAME} and _run_tests_${PROJECT_NAME} does not run simaltaneously.
     # _run_tests_${PROJECT_NAME} is for cleaning test result and run tests.
     # https://github.com/ros/catkin/commit/f931db5c8c14475a9d74ffc65b9dbbe45c98d11d
     if(NOT TARGET run_tests_${PROJECT_NAME})

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -181,6 +181,27 @@ function(ADD_CODE_COVERAGE)
         set(_code_coverage_SOURCE_DIR ${code_coverage_PREFIX}/share/code_coverage)
       endif()
 
+      # check and create python source directories lists
+      set(PROJECT_PYTHON_SOURCE_DIR_CANDIDATES
+        ${PROJECT_SOURCE_DIR}/bin
+        ${PROJECT_SOURCE_DIR}/node_scripts
+        ${PROJECT_SOURCE_DIR}/scripts
+        ${PROJECT_SOURCE_DIR}/src
+      )
+      set(PROJECT_PYTHON_SOURCE_DIRS "")
+      foreach(PROJECT_PYTHON_SOURCE_DIR_CANDIDATE ${PROJECT_PYTHON_SOURCE_DIR_CANDIDATES})
+        if (EXISTS ${PROJECT_PYTHON_SOURCE_DIR_CANDIDATE})
+          list(APPEND PROJECT_PYTHON_SOURCE_DIRS ${PROJECT_PYTHON_SOURCE_DIR_CANDIDATE})
+        endif()
+      endforeach()
+
+      # create depends list
+      set(PYTHON_BASE_COVERAGE_REPORT_DEPENDS
+        create_python_base_coverage_dir
+        ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py
+      )
+      list(APPEND PYTHON_BASE_COVERAGE_REPORT_DEPENDS ${PROJECT_PYTHON_SOURCE_DIRS})
+
       # create python base coverage report
       # generate_base_coverage.py list up python files in the repo and generate base coverage report
       # base coverage report is needed to cover all python files, including non-tested files.
@@ -190,12 +211,7 @@ function(ADD_CODE_COVERAGE)
         COMMAND ${PYTHON_COVERAGE_PATH} report ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No python base report to output"
         COMMAND ${PYTHON_COVERAGE_PATH} xml  -o ${Coverage_NAME}_base_python.xml ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No base python xml to output"
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"
-        DEPENDS create_python_base_coverage_dir
-                ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py
-                ${PROJECT_SOURCE_DIR}/bin
-                ${PROJECT_SOURCE_DIR}/node_scripts
-                ${PROJECT_SOURCE_DIR}/scripts
-                ${PROJECT_SOURCE_DIR}/src
+        DEPENDS ${PYTHON_BASE_COVERAGE_REPORT_DEPENDS}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python_base_coverage
       )
       # hidden test target which depends on building all tests and cleaning test results
@@ -205,12 +221,7 @@ function(ADD_CODE_COVERAGE)
         COMMAND ${PYTHON_COVERAGE_PATH} report ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No python base report to output"
         COMMAND ${PYTHON_COVERAGE_PATH} xml  -o ${Coverage_NAME}_base_python.xml ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No base python xml to output"
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"
-        DEPENDS create_python_base_coverage_dir
-                ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py
-                ${PROJECT_SOURCE_DIR}/bin
-                ${PROJECT_SOURCE_DIR}/node_scripts
-                ${PROJECT_SOURCE_DIR}/scripts
-                ${PROJECT_SOURCE_DIR}/src
+        DEPENDS ${PYTHON_BASE_COVERAGE_REPORT_DEPENDS}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python_base_coverage
       )
     else()

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -163,7 +163,7 @@ function(ADD_CODE_COVERAGE)
       # create hidden meta target which depends on hidden test targets which depend on clean_test_results
       add_custom_target(_run_tests_${PROJECT_NAME})
       # run_tests depends on this hidden target hierarchy to clear test results before running all tests
-     add_dependencies(run_tests _run_tests_${PROJECT_NAME})
+      add_dependencies(run_tests _run_tests_${PROJECT_NAME})
     endif()
 
     if(NOT DEFINED CATKIN_ENABLE_TESTING OR CATKIN_ENABLE_TESTING)

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -166,11 +166,21 @@ function(ADD_CODE_COVERAGE)
         create_python_base_coverage_dir "${CMAKE_COMMAND}" "-E" "make_directory" ${PROJECT_BINARY_DIR}/python_base_coverage
       )
 
+      # find code_coverage path
+      if(code_coverage_SOURCE_DIR)
+        set(_code_coverage_SOURCE_DIR ${code_coverage_SOURCE_DIR})
+      elseif(code_coverage_SOURCE_PREFIX)
+        set(_code_coverage_SOURCE_DIR ${code_coverage_SOURCE_PREFIX})
+      else(code_coverage_SOURCE_PREFIX)
+        set(_code_coverage_SOURCE_DIR ${code_coverage_PREFIX}/share/code_coverage)
+      endif()
+
       # create python base coverage report
       # generate_base_coverage.py list up python files in the repo and generate base coverage report
       # base coverage report is needed to cover all python files, including non-tested files.
       add_custom_target(run_tests_${PROJECT_NAME}_python_base_coverage_report
-        COMMAND rosrun code_coverage generate_base_coverage.py ${PROJECT_SOURCE_DIR} --output ${PROJECT_BINARY_DIR}/python_base_coverage
+        COMMAND ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py ${PROJECT_SOURCE_DIR}
+                --output ${PROJECT_BINARY_DIR}/python_base_coverage
         COMMAND ${PYTHON_COVERAGE_PATH} report ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No python base report to output"
         COMMAND ${PYTHON_COVERAGE_PATH} xml  -o ${Coverage_NAME}_base_python.xml ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No base python xml to output"
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"
@@ -179,7 +189,8 @@ function(ADD_CODE_COVERAGE)
       )
       # hidden test target which depends on building all tests and cleaning test results
       add_custom_target(_run_tests_${PROJECT_NAME}_python_base_coverage_report
-        COMMAND rosrun code_coverage generate_base_coverage.py ${PROJECT_SOURCE_DIR} --output ${PROJECT_BINARY_DIR}/python_base_coverage
+        COMMAND ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py ${PROJECT_SOURCE_DIR}
+                --output ${PROJECT_BINARY_DIR}/python_base_coverage
         COMMAND ${PYTHON_COVERAGE_PATH} report ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No python base report to output"
         COMMAND ${PYTHON_COVERAGE_PATH} xml  -o ${Coverage_NAME}_base_python.xml ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No base python xml to output"
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"

--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -185,6 +185,7 @@ function(ADD_CODE_COVERAGE)
         COMMAND ${PYTHON_COVERAGE_PATH} xml  -o ${Coverage_NAME}_base_python.xml ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No base python xml to output"
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"
         DEPENDS create_python_base_coverage_dir
+                ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python_base_coverage
       )
       # hidden test target which depends on building all tests and cleaning test results
@@ -195,6 +196,7 @@ function(ADD_CODE_COVERAGE)
         COMMAND ${PYTHON_COVERAGE_PATH} xml  -o ${Coverage_NAME}_base_python.xml ${INCLUDE_FLAGS} ${OMIT_FLAGS} || echo "WARNING: No base python xml to output"
         COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/python_base_coverage/${Coverage_NAME}_base_python.xml ${PROJECT_BINARY_DIR}/ || echo "WARNING: No base python xml to copy"
         DEPENDS create_python_base_coverage_dir
+                ${_code_coverage_SOURCE_DIR}/scripts/generate_base_coverage.py
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python_base_coverage
       )
     else()

--- a/package.xml
+++ b/package.xml
@@ -16,5 +16,6 @@
   <depend>lcov</depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python-coverage</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3-coverage</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-magic</depend>
 
 </package>

--- a/scripts/generate_base_coverage.py
+++ b/scripts/generate_base_coverage.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import argparse
+import glob
+import json
+import magic
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('base_dir', type=str)
+    parser.add_argument('--output', '-o', type=str, default='.')
+    args = parser.parse_args()
+
+    python_filepaths = list_python_filepaths(os.path.abspath(args.base_dir))
+    coverage_lines = {}
+    for python_filepath in python_filepaths:
+        coverage_lines[python_filepath] = []
+    coverage_dict = {"lines": coverage_lines}
+    coverage_txt = '!coverage.py: This is a private format, don\'t read it directly!\n'
+    coverage_txt += json.dumps(coverage_dict)
+    os.makedirs(args.output, exist_ok=True)
+    with open(os.path.join(args.output, '.coverage'), 'w') as coverage_f:
+        coverage_f.write(coverage_txt)
+
+
+def list_python_filepaths(base_dir):
+    python_directories = [
+        'bin',
+        'node_scripts',
+        'src',
+        'scripts',
+    ]
+    python_filepaths = []
+    for python_dir in python_directories:
+        for filepath in glob.glob(os.path.join(base_dir, python_dir, '**'), recursive=True):
+            if os.path.isfile(filepath):
+                fileext = os.path.splitext(filepath)[1]
+                if (fileext == '.py' or
+                        (fileext == '' and 'Python' in magic.from_file(filepath))):
+                    python_filepaths.append(filepath)
+    return sorted(set(python_filepaths))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_base_coverage.py
+++ b/scripts/generate_base_coverage.py
@@ -18,6 +18,22 @@ def main():
     parser.add_argument('--output', '-o', type=str, default='.')
     args = parser.parse_args()
 
+    # python .coverage file is json file with comment at the top.
+    # the json structure is like below.
+    #
+    # # comment at the top
+    # !coverage.py: This is a private format, don't read it directly!
+    # {
+    #   "lines": {
+    #     # filepath: [list of hitting lines]
+    #     "/home/gitai/gitai/catkin_ws/src/sample_package/scripts/hoge.py": [1, 3, 4, 5],
+    #     "/home/gitai/gitai/catkin_ws/src/sample_package/scripts/fuga.py": [],
+    #     ...
+    #   }
+    # }
+    #
+    # If you want to make .coverage file with no hitting lines,
+    # you need to register empty list as the list of hitting lines.
     python_filepaths = list_python_filepaths(os.path.abspath(args.base_dir))
     coverage_lines = {}
     for python_filepath in python_filepaths:

--- a/scripts/generate_base_coverage.py
+++ b/scripts/generate_base_coverage.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+# generate_base_coverage.py
+# this script lists up all python files in repo and generate base coverage report.
+# the base coverage report covers all python files, including non-tested files.
+# with the base coverage report, we can calculate coverage with non-tested files, too.
+
 import argparse
 import glob
 import json


### PR DESCRIPTION
this PR adds python base coverage reports.
base coverage report includes python files in the repo and hits no lines as coverage. (0% coverage).
python files under `bin`, `src`, `scripts` and `node_scripts` are listed up in the base report.

This file is needed to calculate coverage percentage including codes with no-test codes.
this PR also supports repo which does not have any test codes to calculate coverage (it will be 0%)