### PR TITLE
add `--include-python-directories` arguments in `generate_base_coverage.py`

### DIFF
--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -171,13 +171,6 @@ function(ADD_CODE_COVERAGE)
     endif()
 
     if(NOT DEFINED CATKIN_ENABLE_TESTING OR CATKIN_ENABLE_TESTING)
-      # set include python flags
-      set(INCLUDE_PYTHON_FLAGS "")
-      if(NOT "${Coverage_INCLUDE_PYTHON_DIRECTORIES}" STREQUAL "")
-        list(APPEND INCLUDE_PYTHON_FLAGS "--include-python-directories")
-        list(APPEND INCLUDE_PYTHON_FLAGS ${Coverage_INCLUDE_PYTHON_DIRECTORIES})
-      endif()
-
       # create python base coverage directory
       add_custom_target(
         create_python_base_coverage_dir "${CMAKE_COMMAND}" "-E" "make_directory" ${PROJECT_BINARY_DIR}/python_base_coverage
@@ -192,19 +185,29 @@ function(ADD_CODE_COVERAGE)
         set(_code_coverage_SOURCE_DIR ${code_coverage_PREFIX}/share/code_coverage)
       endif()
 
+      # list up python source directory candidates
+      if("${Coverage_INCLUDE_PYTHON_DIRECTORIES}" STREQUAL "")
+        set(PROJECT_PYTHON_SOURCE_DIR_CANDIDATES bin node_scripts scripts src)
+      else()
+        set(PROJECT_PYTHON_SOURCE_DIR_CANDIDATES ${Coverage_INCLUDE_PYTHON_DIRECTORIES})
+      endif()
+
       # check and create python source directories lists
-      set(PROJECT_PYTHON_SOURCE_DIR_CANDIDATES
-        ${PROJECT_SOURCE_DIR}/bin
-        ${PROJECT_SOURCE_DIR}/node_scripts
-        ${PROJECT_SOURCE_DIR}/scripts
-        ${PROJECT_SOURCE_DIR}/src
-      )
       set(PROJECT_PYTHON_SOURCE_DIRS "")
+      set(PROJECT_PYTHON_SOURCE_DIRS_RELATIVE "")
       foreach(PROJECT_PYTHON_SOURCE_DIR_CANDIDATE ${PROJECT_PYTHON_SOURCE_DIR_CANDIDATES})
-        if (EXISTS ${PROJECT_PYTHON_SOURCE_DIR_CANDIDATE})
-          list(APPEND PROJECT_PYTHON_SOURCE_DIRS ${PROJECT_PYTHON_SOURCE_DIR_CANDIDATE})
+        if (EXISTS ${PROJECT_SOURCE_DIR}/${PROJECT_PYTHON_SOURCE_DIR_CANDIDATE})
+          list(APPEND PROJECT_PYTHON_SOURCE_DIRS ${PROJECT_SOURCE_DIR}/${PROJECT_PYTHON_SOURCE_DIR_CANDIDATE})
+          list(APPEND PROJECT_PYTHON_SOURCE_DIRS_RELATIVE ${PROJECT_PYTHON_SOURCE_DIR_CANDIDATE})
         endif()
       endforeach()
+
+      # set include python flags
+      set(INCLUDE_PYTHON_FLAGS "")
+      if (NOT "${PROJECT_PYTHON_SOURCE_DIRS_RELATIVE}" STREQUAL "")
+        list(APPEND INCLUDE_PYTHON_FLAGS "--include-python-directories")
+        list(APPEND INCLUDE_PYTHON_FLAGS ${PROJECT_PYTHON_SOURCE_DIRS_RELATIVE})
+      endif()
 
       # create depends list
       set(PYTHON_BASE_COVERAGE_REPORT_DEPENDS

--- a/scripts/generate_base_coverage.py
+++ b/scripts/generate_base_coverage.py
@@ -8,14 +8,20 @@
 import argparse
 import glob
 import json
-import magic
 import os
+
+import magic
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('base_dir', type=str)
     parser.add_argument('--output', '-o', type=str, default='.')
+    parser.add_argument('--include-python-directories',
+                        '-i',
+                        type=str,
+                        nargs='*',
+                        default=['bin', 'node_scripts', 'src', 'scripts'])
     args = parser.parse_args()
 
     # python .coverage file is json file with comment at the top.
@@ -34,7 +40,8 @@ def main():
     #
     # If you want to make .coverage file with no hitting lines,
     # you need to register empty list as the list of hitting lines.
-    python_filepaths = list_python_filepaths(os.path.abspath(args.base_dir))
+    python_filepaths = list_python_filepaths(os.path.abspath(args.base_dir),
+                                             args.include_python_directories)
     coverage_lines = {}
     for python_filepath in python_filepaths:
         coverage_lines[python_filepath] = []
@@ -46,16 +53,11 @@ def main():
         coverage_f.write(coverage_txt)
 
 
-def list_python_filepaths(base_dir):
-    python_directories = [
-        'bin',
-        'node_scripts',
-        'src',
-        'scripts',
-    ]
+def list_python_filepaths(base_dir, python_directories):
     python_filepaths = []
     for python_dir in python_directories:
-        for filepath in glob.glob(os.path.join(base_dir, python_dir, '**'), recursive=True):
+        for filepath in glob.glob(os.path.join(base_dir, python_dir, '**'),
+                                  recursive=True):
             if os.path.isfile(filepath):
                 fileext = os.path.splitext(filepath)[1]
                 if (fileext == '.py' or


### PR DESCRIPTION
this PR adds `include python directories` arguments for include.
with this PR, we can customize python script directories.