### PR TITLE
append include python directories to default lists

### DIFF
--- a/cmake/Modules/CodeCoverage.cmake
+++ b/cmake/Modules/CodeCoverage.cmake
@@ -198,10 +198,9 @@ function(ADD_CODE_COVERAGE)
       endif()
 
       # list up python source directory candidates
-      if("${Coverage_INCLUDE_PYTHON_DIRECTORIES}" STREQUAL "")
-        set(PROJECT_PYTHON_SOURCE_DIR_CANDIDATES bin node_scripts scripts src)
-      else()
-        set(PROJECT_PYTHON_SOURCE_DIR_CANDIDATES ${Coverage_INCLUDE_PYTHON_DIRECTORIES})
+      set(PROJECT_PYTHON_SOURCE_DIR_CANDIDATES bin ci_scripts node_scripts scripts src)
+      if(NOT "${Coverage_INCLUDE_PYTHON_DIRECTORIES}" STREQUAL "")
+        list(APPEND PROJECT_PYTHON_SOURCE_DIR_CANDIDATES ${Coverage_INCLUDE_PYTHON_DIRECTORIES})
       endif()
 
       # check and create python source directories lists


### PR DESCRIPTION
now `INCLUDE_PYTHON_DIRECTORIES` are just overwriting the default python source directory candidates.
this PR change the behavior to append it.

- append  `INCLUDE_PYTHON_DIRECTORIES` 
- add `ci_scripts` in default directories.